### PR TITLE
Fix import of statically built CSS

### DIFF
--- a/src/main/webapp/sass/swc.scss
+++ b/src/main/webapp/sass/swc.scss
@@ -2,13 +2,14 @@
 @use 'core' as swc;
 @use '../css/bootstrap-custom-theme.min.css';
 
-// We load the minified CSS for SRC because it contains styles that are not in the SCSS build. These missing styles were
-// imported in JSX/TSX and loaded through Webpack. The synapse-react-client UMD bundler identifies these loaded CSS files
-// and includes them in this minified CSS file. This is why
-// We **do** use the UMD JavaScript build, so we rely on these styles to be loaded.
-@use 'synapse-react-client/dist/umd/synapse-react-client.production.min.css';
+// Even though we are loading the source Sass stylesheets from synapse-react-client below, we first load the minified
+// CSS for SRC because it contains styles that are not in the distributed source SCSS. The missing styles were imported
+// in TypeScript/TSX files and loaded + compiled by Vite, so Sass never compiled them. The synapse-react-client bundle
+// step includes these styles in this minified CSS file.
+@use 'synapse-react-client/dist/style.css';
 
-// Load the SCSS build after the minified build so styles with overrides take higher priority
+// Include the source synapse-react-client SCSS files after the minified build so styles that include our variable
+// overrides take higher priority
 @use 'synapse-react-client/dist/style/main.scss' with (
   $primary-action-color: swc.$synapse-blue,
   $secondary-action-color: swc.$synapse-green,


### PR DESCRIPTION
- Fix import of statically built css. Note that Vite now handles importing CSS from dependencies, so this will just have CSS/SCSS imported via JS in synapse-react-client that is not sourced from node_modules